### PR TITLE
Lgbm

### DIFF
--- a/src/olorenchemengine/basics.py
+++ b/src/olorenchemengine/basics.py
@@ -522,12 +522,12 @@ class TorchMLP(BaseModel):
 
         self.network = torch.load(io.BytesIO(d["save"]))
 
-class LGBoostModel(BaseSKLearnModel, BaseObject):
-    """Light Gradient Boosting Model
+class LGBMModel(BaseSKLearnModel, BaseObject):
+    """Light Gradient-Boosting Machine Model
 
         Parameters:
-            representation (BaseRepresentation): representation to use for the model
-            **kwargs: parameters to pass to LGB Model
+            representation (BaseRepresentation): The representation to use for the model
+            **kwargs: parameters for LGBM to pass. See a list of full parameters at LGBM documentation https://lightgbm.readthedocs.io/en/v3.3.2/
     """
 
     @log_arguments

--- a/src/olorenchemengine/basics.py
+++ b/src/olorenchemengine/basics.py
@@ -522,6 +522,23 @@ class TorchMLP(BaseModel):
 
         self.network = torch.load(io.BytesIO(d["save"]))
 
+class LGBoostModel(BaseSKLearnModel, BaseObject):
+    """Light Gradient Boosting Model
+
+        Parameters:
+            representation (BaseRepresentation): representation to use for the model
+            **kwargs: parameters to pass to LGB Model
+    """
+
+    @log_arguments
+    def __init__(self, representation, **kwargs):
+        import lightgbm as lgbm
+
+        regressor = lgbm.LGBMRegressor(**kwargs)
+
+        classifier = lgbm.LGBMClassifier(**kwargs)
+
+        super().__init__(representation, regressor, classifier, log=False, **kwargs)
 
 class XGBoostModel(BaseSKLearnModel, BaseObject):
     """XGBoost model


### PR DESCRIPTION
- Over 100 parameters you can pass to LGBM so left the parameters blank and link to docs
- GPU usage (device='gpu') requires special installation (on linux throws "[LightGBM] [Fatal] GPU Tree Learner was not enabled in this build. Please recompile with CMake option -DUSE_GPU=1" and seems there are unique instructions for windows also)